### PR TITLE
Fixes building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pip install secp256k1-zkp-mw
 
 and you're good to go!
 
+If you're installing this module on Windows you'll need to temporarily change your `TEMP` environmental variable to something with a short path, like `C:\temp`, and create that folder before running the above command. This is required to workaround a limitation with the Visual Studio C/C++ compiler and files with long path names. You can revert the change to your `TEMP` environmental variable after the module is installed.
+
 ## Development
 
 Locally, you may install this this module manually at arbitrary height of the [MW fork of secp256k1-zkp](https://github.com/mimblewimble/secp256k1-zkp) using submodule.

--- a/build.py
+++ b/build.py
@@ -29,6 +29,8 @@ def download_library(basepath):
                 dirname = tf.getnames()[0].partition('/')[0]
                 tf.extractall()
                 tarpath = os.path.join(basepath, dirname)
+                if os.path.exists(libdir):
+                    os.rmdir(libdir)
                 os.rename(tarpath, libdir)
         else:
             raise SystemExit(


### PR DESCRIPTION
os.rename fails on Windows if the destination already exists.